### PR TITLE
Check to see if video and photo folders exist

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -11,6 +11,9 @@ def parse_videos():
     """
     Prints the total number of video files inside the /videos foler.
     """
+    if not os.path.exists('videos'):
+        return
+
     _, __, filenames = os.walk('videos').next()
     print('Number of Videos: {}'.format(len(filenames)))
 
@@ -25,6 +28,10 @@ def parse_photos():
     The actual photos are separated by album and have their own folders.
     There is a corresponding HTML file for each with metadata and the comments.
     """
+
+    if not os.path.exists('photos'):
+        return
+
     photo_count = 0
     photo_albums = []
     comment_counts = {}


### PR DESCRIPTION
Apparently I have never uploaded a video to Facebook and the script was crashing because I didn't have a videos folder. I added the same check for photos as well just to be safe.